### PR TITLE
feat: implement BIP39 seed phrase with optional GPG encryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Nym Client Configuration
+NYM_CLIENT_ID=default
+NYM_SDK_STORAGE=storage/default
+
+# Database Configuration
+DATABASE_PATH=storage/discovery.db
+
+# Cryptography Configuration
+KEYS_DIR=storage/keys
+SECRET_PATH=secrets/seed_phrase
+SEED_PHRASE_ENCRYPTED=false
+
+# Logging Configuration
+LOG_FILE_PATH=logs/server.log
+RUST_LOG=info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,170 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+**nymstr-server** is a Rust-based discovery and message relay service for nymCHAT clients using the Nym Mixnet SDK. It provides user registration, authentication, and encrypted message routing over the Nym privacy network.
+
+## Commands
+
+### Build & Run
+- `cargo build --release` - Build the project in release mode
+- `cargo run --release` - Run the server
+- `cargo run --release -- --generate` or `cargo run --release -- -g` - Generate server keypair
+
+### Testing
+- `cargo test` - Run all tests across all modules
+- `cargo test --test <test_name>` - Run a specific test
+- `RUST_LOG=debug cargo test` - Run tests with debug logging
+
+### Development
+- `cargo check` - Quick compile check without building
+- `RUST_LOG=debug cargo run` - Run with debug logging
+- `RUST_LOG=trace cargo run` - Run with trace logging (most verbose)
+
+## Architecture
+
+### Core Components
+
+**main.rs** - Entry point that:
+- Handles CLI args (--generate flag for keypair generation)
+- Initializes environment, logging, and storage directories
+- Connects to Nym mixnet and processes incoming messages via `MessageUtils`
+- Uses `tokio::select!` to handle shutdown signals gracefully
+
+**crypto_utils.rs** - PGP-based cryptography:
+- Migrated from OpenSSL ECDSA to PGP (pgp crate) for key management
+- Uses BIP39 24-word seed phrase (256-bit entropy) as master password
+- Encrypts private keys with AES-256-GCM using PBKDF2-derived keys from seed phrase
+- Generates RSA-2048 keypairs for users and server
+- Signs messages by hashing with SHA-256 first, then creating PGP signatures
+- Verifies signatures supporting both armored and base64-encoded formats
+- All keys stored in `KEYS_DIR` (default: `storage/keys/`)
+
+**db_utils.rs** - SQLite database interface:
+- Uses SQLx 0.8 with async/await
+- Schema: `users` table (username, publicKey, senderTag) and `groups` table
+- WAL mode and foreign keys enabled
+- Key methods: `add_user()`, `get_user_by_username()`, `update_user_field()`
+- Usernames are primary keys
+
+**message_utils.rs** - Message routing and protocol handler:
+- Supports both **legacy format** (backward compatibility) and **unified format** (new protocol with `type` and `action` fields)
+- Handles authentication flows: registration and login with nonce-based challenges
+- Routes messages between users via AnonymousSenderTag (ephemeral Nym addresses)
+- Supports MLS encrypted messages: extracts `conversation_id` and `mls_message` from payload
+- Server signs all responses using its own keypair (client_id)
+- In-memory HashMaps track pending registrations/logins by sender_tag
+
+**env_loader.rs** - Simple wrapper around `dotenvy` to load `.env` files
+
+**log_config.rs** - Configures fern logger:
+- Colored console output (red=error, yellow=warn, green=info, cyan=debug)
+- Log level controlled by `RUST_LOG` env var (default: Info)
+- Logs to both file and stdout with RFC3339 timestamps
+
+### Seed Phrase Management
+
+**First Run Behavior:**
+- Generates a BIP39 24-word mnemonic (256 bits of entropy)
+- Displays seed phrase ONCE to user for backup
+- Prompts user about GPG encryption preference
+- Stores in `secrets/seed_phrase` (plaintext) or `secrets/seed_phrase.enc` (GPG-encrypted)
+
+**Seed Phrase Loading** (see `load_seed_phrase()` in main.rs):
+- Checks `SEED_PHRASE_ENCRYPTED` env var
+- If true: decrypts `secrets/seed_phrase.enc` using GPG via shell command
+- If false: reads plaintext from `secrets/seed_phrase`
+- Empty or missing seed phrase triggers generation flow
+
+**Optional GPG Encryption:**
+- Use `scripts/encrypt_seed.sh` to encrypt existing seed phrase
+- Uses AES256 symmetric encryption
+- Securely deletes plaintext version with `shred` or `srm`
+- Server prompts for GPG password on startup when encrypted
+
+**Security Model:**
+- Seed phrase → PBKDF2 (100k iterations) → AES-256-GCM key
+- Each private key has unique salt and IV
+- User must backup seed phrase - file loss without backup = unrecoverable
+
+### Authentication Flow
+
+1. **Registration**: Client sends `register` → Server responds with `challenge` (nonce) → Client signs nonce → Server verifies signature → User added to DB
+2. **Login**: Client sends `login` → Server responds with `challenge` (nonce) → Client signs nonce → Server verifies signature and updates senderTag
+
+Username validation: alphanumeric, `-`, and `_` only.
+
+### Message Format
+
+**Unified Format** (preferred):
+```json
+{
+  "type": "message|response",
+  "action": "send|query|register|login|...",
+  "sender": "username",
+  "recipient": "username",
+  "payload": { ... },
+  "signature": "base64_signature",
+  "timestamp": "RFC3339"
+}
+```
+
+**Legacy Format** (backward compatibility):
+```json
+{
+  "action": "send|query|...",
+  "content": "...",
+  "signature": "..."
+}
+```
+
+### Nym Mixnet Integration
+
+- Uses `nym-sdk` from the Nym GitHub repository (master branch)
+- Storage paths configured via `NYM_SDK_STORAGE` (defaults to `storage/{NYM_CLIENT_ID}`)
+- Messages routed using AnonymousSenderTag (SURB-based replies)
+- Client connects once at startup and maintains persistent connection until Ctrl+C
+
+## Configuration
+
+Environment variables (see `.env.example`):
+- `NYM_CLIENT_ID` - Unique identifier for this discovery node (default: `default`)
+- `NYM_SDK_STORAGE` - Nym SDK storage directory (default: `storage/${NYM_CLIENT_ID}`)
+- `DATABASE_PATH` - SQLite database path (default: `storage/discovery.db`)
+- `KEYS_DIR` - Directory for PGP keys (default: `storage/keys`)
+- `SECRET_PATH` - Seed phrase file path (default: `secrets/seed_phrase`)
+- `SEED_PHRASE_ENCRYPTED` - Whether seed phrase is GPG-encrypted (default: `false`)
+- `LOG_FILE_PATH` - Log file path (default: `logs/server.log`)
+- `RUST_LOG` - Log level (trace|debug|info|warn|error, default: `info`)
+
+Setup:
+```bash
+cp .env.example .env
+cargo run --release  # Generates seed phrase on first run
+# Back up the displayed seed phrase!
+# Optionally: ./scripts/encrypt_seed.sh
+cargo run --release -- --generate  # Generate server keys
+cargo run --release  # Start server
+```
+
+**First Run:** Server auto-generates BIP39 seed phrase, displays it once for backup, and stores in `secrets/seed_phrase`.
+
+**Optional Encryption:** Run `./scripts/encrypt_seed.sh` to encrypt with GPG, then set `SEED_PHRASE_ENCRYPTED=true` in `.env`.
+
+## Testing
+
+All modules have comprehensive test coverage:
+- Unit tests use `tempfile` for isolated temporary directories
+- Database tests use `tokio-test` and async test macros
+- Crypto tests verify key generation, encryption/decryption, signing/verification
+- Tests clean up after themselves (removing temp env vars)
+
+## Important Notes
+
+- **Signature verification always hashes messages with SHA-256 before verifying** (crypto_utils.rs:138-144)
+- Server must generate its own keypair before first run (use `--generate` flag)
+- SenderTags are updated on login to handle ephemeral Nym client addresses
+- Edition is set to `2024` in Cargo.toml (uses latest Rust edition)
+- License: Apache-2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "chrono"] }
 nym-sdk = { git = "https://github.com/nymtech/nym", branch = "master" }
 uuid = { version = "1", features = ["v4"] }
 pgp = "0.13"
+bip39 = "2.0"
+ed25519-zebra = { version = "4.1", features = ["alloc"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -4,23 +4,54 @@ A discovery and message relay service for nymCHAT clients, fully rewritten in Ru
 
 ## Configuration
 
-Copy the example environment file, create a secrets directory, and provide your encryption password:
+### Quick Start
 
+1. Copy the example environment file:
 ```bash
 cp .env.example .env
-mkdir -p secrets logs
-echo "your-secure-password" > secrets/encryption_password
-chmod 600 secrets/encryption_password
 ```
 
-Edit `.env` to customize any of the following variables:
+2. Run the server - it will automatically generate a BIP39 seed phrase on first run:
+```bash
+cargo run --release
+```
 
-- `NYM_CLIENT_ID`: Unique identifier for this discovery node.
-- `NYM_SDK_STORAGE`: Path to the Nym SDK storage directory (defaults to `storage/${NYM_CLIENT_ID}` if unset).
-- `DATABASE_PATH`: Path to the SQLite database file.
-- `KEYS_DIR`: Directory for user encryption keys.
-- `SECRET_PATH`: Path to the file containing your encryption password.
-- `LOG_FILE_PATH`: File path for log output.
+On first run, the server will:
+- Display a 24-word seed phrase
+- Prompt you to back it up (write it down!)
+- Ask if you want to encrypt it with a password
+- Store it in `secrets/seed_phrase`
+
+**⚠️ IMPORTANT**: Write down your seed phrase! It protects all encrypted keys. If you lose both the seed phrase file AND your backup, encrypted keys cannot be recovered.
+
+### Optional: Encrypt Your Seed Phrase
+
+For enhanced security, encrypt your seed phrase with GPG:
+
+```bash
+./scripts/encrypt_seed.sh
+```
+
+This will:
+- Encrypt `secrets/seed_phrase` with a password of your choice
+- Create `secrets/seed_phrase.enc`
+- Securely delete the plaintext version
+- Prompt you to add `SEED_PHRASE_ENCRYPTED=true` to `.env`
+
+When encrypted, you'll need to enter your GPG password each time the server starts.
+
+### Environment Variables
+
+Edit `.env` to customize these variables:
+
+- `NYM_CLIENT_ID`: Unique identifier for this discovery node (default: `default`)
+- `NYM_SDK_STORAGE`: Path to the Nym SDK storage directory (default: `storage/${NYM_CLIENT_ID}`)
+- `DATABASE_PATH`: Path to the SQLite database file (default: `storage/discovery.db`)
+- `KEYS_DIR`: Directory for user encryption keys (default: `storage/keys`)
+- `SECRET_PATH`: Path to the seed phrase file (default: `secrets/seed_phrase`)
+- `SEED_PHRASE_ENCRYPTED`: Whether seed phrase is GPG-encrypted (default: `false`)
+- `LOG_FILE_PATH`: File path for log output (default: `logs/server.log`)
+- `RUST_LOG`: Log level - `trace`, `debug`, `info`, `warn`, or `error` (default: `info`)
 
 ## Running Locally
 

--- a/scripts/encrypt_seed.sh
+++ b/scripts/encrypt_seed.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${YELLOW}  Seed Phrase Encryption Script${NC}"
+echo -e "${YELLOW}═══════════════════════════════════════════════════════════════${NC}"
+echo ""
+
+# Get SECRET_PATH from .env or use default
+SECRET_PATH=$(grep -E '^SECRET_PATH=' .env 2>/dev/null | cut -d'=' -f2 || echo "secrets/seed_phrase")
+
+if [ ! -f "$SECRET_PATH" ]; then
+    echo -e "${RED}Error: Seed phrase file not found at: $SECRET_PATH${NC}"
+    echo "Please run the server first to generate a seed phrase."
+    exit 1
+fi
+
+if [ -f "${SECRET_PATH}.enc" ]; then
+    echo -e "${YELLOW}Warning: Encrypted seed phrase already exists at: ${SECRET_PATH}.enc${NC}"
+    read -p "Overwrite it? (y/N): " overwrite
+    if [ "$overwrite" != "y" ] && [ "$overwrite" != "Y" ]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo -e "${GREEN}Found plaintext seed phrase at: $SECRET_PATH${NC}"
+echo ""
+echo "You will be prompted to enter a password to encrypt the seed phrase."
+echo "Remember this password - you'll need it every time the server starts."
+echo ""
+
+# Encrypt with GPG
+if ! gpg --symmetric --cipher-algo AES256 --output "${SECRET_PATH}.enc" "$SECRET_PATH"; then
+    echo -e "${RED}Error: GPG encryption failed${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}✓ Seed phrase encrypted successfully!${NC}"
+echo -e "  Encrypted file: ${SECRET_PATH}.enc"
+echo ""
+
+# Securely delete plaintext version
+echo "Securely deleting plaintext seed phrase..."
+if command -v shred &> /dev/null; then
+    shred -u "$SECRET_PATH"
+    echo -e "${GREEN}✓ Plaintext seed phrase securely deleted with shred${NC}"
+elif command -v srm &> /dev/null; then
+    srm "$SECRET_PATH"
+    echo -e "${GREEN}✓ Plaintext seed phrase securely deleted with srm${NC}"
+else
+    # Fallback: overwrite with random data before deletion
+    dd if=/dev/urandom of="$SECRET_PATH" bs=1 count=$(stat -f%z "$SECRET_PATH" 2>/dev/null || stat -c%s "$SECRET_PATH") conv=notrunc 2>/dev/null
+    rm "$SECRET_PATH"
+    echo -e "${YELLOW}⚠  Plaintext seed phrase deleted (secure deletion tool not available)${NC}"
+fi
+
+echo ""
+echo -e "${YELLOW}═══════════════════════════════════════════════════════════════${NC}"
+echo -e "${YELLOW}  Next Steps:${NC}"
+echo -e "${YELLOW}═══════════════════════════════════════════════════════════════${NC}"
+echo ""
+echo "1. Add to your .env file:"
+echo -e "   ${GREEN}SEED_PHRASE_ENCRYPTED=true${NC}"
+echo ""
+echo "2. Restart the server. You'll be prompted for your GPG password."
+echo ""
+echo -e "${RED}IMPORTANT: If you lose your GPG password, you will need your${NC}"
+echo -e "${RED}backed-up seed phrase to recover access to encrypted keys.${NC}"
+echo ""


### PR DESCRIPTION
Major Changes:
- Add bip39 crate for 24-word mnemonic generation (256-bit entropy)
- Replace manual password setup with auto-generated seed phrase on first run
- Implement seed phrase loading with optional GPG decryption support
- Create encrypt_seed.sh script for optional AES256 GPG encryption
- Add SEED_PHRASE_ENCRYPTED env var to control encryption mode

Security Improvements:
- High-entropy seed phrase (256 bits) vs user-chosen weak passwords
- BIP39 standard format for backup/recovery
- Optional GPG encryption for enhanced security
- User prompted to backup seed phrase on first run
- Seed phrase used as master password for PBKDF2 key derivation

File Changes:
- Cargo.toml: Add bip39 and ed25519-zebra dependencies
- src/main.rs: Add generate_and_store_seed_phrase() and load_seed_phrase() functions
- .env.example: Update SECRET_PATH to seeds/seed_phrase, add SEED_PHRASE_ENCRYPTED
- README.md: Complete rewrite of configuration section with new workflow
- CLAUDE.md: Add "Seed Phrase Management" section documenting the architecture
- scripts/encrypt_seed.sh: New script for GPG encryption with secure deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)